### PR TITLE
Added dependencies for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,17 @@
             <version>1.50</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
+            <type>jar</type>
+        </dependency>
             
     </dependencies>
     


### PR DESCRIPTION
I added the same dependencies we used for TLS-Attacker's Transport module to resolve an error related to JAXB APIs not included in Java 11 anymore.